### PR TITLE
np.bool is deprecated in numpy. Changed to bool. (#3)

### DIFF
--- a/subpixel_edges/final_detector_iter0.py
+++ b/subpixel_edges/final_detector_iter0.py
@@ -19,8 +19,8 @@ def main_iter0(F, threshold, iters, order):
     abs_Fy_inner = np.abs(Fy[5:rows - 5, 2: cols - 2])
     abs_Fx_inner = np.abs(Fx[2:rows - 2, 5: cols - 5])
 
-    Ey = np.zeros((rows, cols), dtype=np.bool)
-    Ex = np.zeros((rows, cols), dtype=np.bool)
+    Ey = np.zeros((rows, cols), dtype=bool)
+    Ex = np.zeros((rows, cols), dtype=bool)
 
     Ey[5: rows - 5, 2: cols - 2] = np.logical_and.reduce([
         grad[5: rows - 5, 2: cols - 2] > threshold,

--- a/subpixel_edges/final_detector_iter1.py
+++ b/subpixel_edges/final_detector_iter1.py
@@ -29,8 +29,8 @@ def main_iter1(F, threshold, iters, order):
     absGyInner = np.abs(Gy[5:rows - 5, 2: cols - 2])
     absGxInner = np.abs(Gx[2:rows - 2, 5: cols - 5])
 
-    Ey = np.zeros((rows, cols), dtype=np.bool)
-    Ex = np.zeros((rows, cols), dtype=np.bool)
+    Ey = np.zeros((rows, cols), dtype=bool)
+    Ex = np.zeros((rows, cols), dtype=bool)
 
     Ey[5: rows - 5, 2: cols - 2] = np.logical_and.reduce([
         grad[5: rows - 5, 2: cols - 2] > threshold,

--- a/subpixel_edges/final_detector_iterN.py
+++ b/subpixel_edges/final_detector_iterN.py
@@ -31,8 +31,8 @@ def main_iterN(F, threshold, iters, order):
     absGyInner = np.abs(Gy[5:rows - 5, 2: cols - 2])
     absGxInner = np.abs(Gx[2:rows - 2, 5: cols - 5])
 
-    Ey = np.zeros((rows, cols), dtype=np.bool)
-    Ex = np.zeros((rows, cols), dtype=np.bool)
+    Ey = np.zeros((rows, cols), dtype=bool)
+    Ex = np.zeros((rows, cols), dtype=bool)
 
     Ey[5: rows - 5, 2: cols - 2] = np.logical_and.reduce([
         grad[5: rows - 5, 2: cols - 2] > threshold,


### PR DESCRIPTION
* Update final_detector_iterN.py

np.bool is deprecated in numpy.
Changed to bool.

* Update final_detector_iter1.py (#1)

np.bool is deprecated in numpy.
Changed to bool.

* Update final_detector_iter0.py (#2)

np.bool is deprecated in numpy.
Changed to bool.